### PR TITLE
Catch and show Artifact fetch error

### DIFF
--- a/src/components/pages/outpoint/index.tsx
+++ b/src/components/pages/outpoint/index.tsx
@@ -38,78 +38,87 @@ const OutpointPage = async ({
 	// O2 - Payment to lister
 	// O3 - Market Fee
 	// O4 - Change
-	if (artifact?.data?.list && !artifact.script) {
-		const { promise } = http.customFetch<OrdUtxo>(
-			`${API_HOST}/api/txos/${artifact.outpoint}?script=true`
-		);
+	try {
+		if (artifact?.data?.list && !artifact.script) {
+			const { promise } = http.customFetch<OrdUtxo>(
+				`${API_HOST}/api/txos/${artifact.outpoint}?script=true`
+			);
 
-		const { script } = await promise;
-		artifact.script = script;
-	}
+			const { script } = await promise;
+			artifact.script = script;
+		}
 
-	// if (
-	//   (price === 0 ? minimumMarketFee + price : price * 1.04) >=
-	//   sumBy(fundingUtxos, "satoshis") + P2PKHInputSize * fundingUtxos.length
-	// ) {
-	//   toast.error("Not enough Bitcoin!", toastErrorProps);
-	// }
+		// if (
+		//   (price === 0 ? minimumMarketFee + price : price * 1.04) >=
+		//   sumBy(fundingUtxos, "satoshis") + P2PKHInputSize * fundingUtxos.length
+		// ) {
+		//   toast.error("Not enough Bitcoin!", toastErrorProps);
+		// }
 
-	return (
-		<div className="mx-auto flex flex-col p-2 md:p-0 min-h-64">
-			{artifact && (
-				<>
-					<h2 className={`text-2xl mb-4  ${notoSerif.className}`}>
-						{displayName(artifact, false)}
-					</h2>
-					<div className="flex flex-col md:flex-row gap-4">
-						{artifact?.origin?.data?.insc && (
-							<Artifact
-								artifact={artifact}
-								size={550}
-								sizes={"100vw"}
-								glow={true}
-								classNames={{
-									media: "overflow-hidden",
-									wrapper: `overflow-hidden h-[550px] relative ${
-										// activeTab === OutpointTab.Inscription ? "md:w-1/3" : "md:w-2/3"
-										"w-fit"
-									}`,
-								}}
-								showListingTag={true}
-							/>
-						)}
-						<div className="divider" />
-						<div
-							className={`w-full ${
-								// activeTab === OutpointTab.Inscription ? "md:w-1/3" : "md:w-1/3"
-								"w-full"
-							} mx-auto`}
-						>
-							<OutpointTabs
-								activeTab={activeTab}
-								outpoint={outpoint}
-								owner={
-									artifact.spend ||
-									!!artifact.origin?.data?.bsv20
-										? undefined
-										: artifact?.owner
-								}
-								hasToken={!!artifact.origin?.data?.bsv20}
-								isListing={!!artifact.data?.list}
-								isCollection={
-									artifact.origin?.data?.map?.subType ===
-										"collection" ||
-									artifact.origin?.data?.map?.subType ===
-										"collectionItem"
-								}
-							/>
-							{content}
+		return (
+			<div className="mx-auto flex flex-col p-2 md:p-0 min-h-64">
+				{artifact && (
+					<>
+						<h2 className={`text-2xl mb-4  ${notoSerif.className}`}>
+							{displayName(artifact, false)}
+						</h2>
+						<div className="flex flex-col md:flex-row gap-4">
+							{artifact?.origin?.data?.insc && (
+								<Artifact
+									artifact={artifact}
+									size={550}
+									sizes={"100vw"}
+									glow={true}
+									classNames={{
+										media: "overflow-hidden",
+										wrapper: `overflow-hidden h-[550px] relative ${
+											// activeTab === OutpointTab.Inscription ? "md:w-1/3" : "md:w-2/3"
+											"w-fit"
+										}`,
+									}}
+									showListingTag={true}
+								/>
+							)}
+							<div className="divider" />
+							<div
+								className={`w-full ${
+									// activeTab === OutpointTab.Inscription ? "md:w-1/3" : "md:w-1/3"
+									"w-full"
+								} mx-auto`}
+							>
+								<OutpointTabs
+									activeTab={activeTab}
+									outpoint={outpoint}
+									owner={
+										artifact.spend ||
+										!!artifact.origin?.data?.bsv20
+											? undefined
+											: artifact?.owner
+									}
+									hasToken={!!artifact.origin?.data?.bsv20}
+									isListing={!!artifact.data?.list}
+									isCollection={
+										artifact.origin?.data?.map?.subType ===
+											"collection" ||
+										artifact.origin?.data?.map?.subType ===
+											"collectionItem"
+									}
+								/>
+								{content}
+							</div>
 						</div>
-					</div>
-				</>
-			)}
-		</div>
-	);
+					</>
+				)}
+			</div>
+		);
+	} catch (error) {
+		const message =
+			(error as Error).message === http.HttpErrors.NotFoundRequestError
+				? "Artifact not found"
+				: "Something went wrong";
+
+		return <div className="mx-auto my-4 text-center">{message}</div>;
+	}
 };
 
 export default OutpointPage;


### PR DESCRIPTION
This PR adds error catching when fetching an artifact fails.

### Current behaviour

**Update:** GorillaPool and Ordfs started returning data for outpoints that were 404-ing

When GorillaPool returns 404 for the outpoint:
<img width="1339" alt="image" src="https://github.com/BitcoinSchema/1sat-website/assets/160716963/cbc92e38-e8c2-4a47-a08e-d04d24986391">

Loading that outpoint in the app causes it to crash:
<img width="1115" alt="image" src="https://github.com/BitcoinSchema/1sat-website/assets/160716963/bc23b9a5-b50b-4f82-9723-a808003bda07">

### Updated behaviour

Added a try-catch to handle the error and show error message:
<img width="1681" alt="image" src="https://github.com/BitcoinSchema/1sat-website/assets/160716963/c5575ee7-fc2b-4cc7-8682-890f5fdb1b73">

