### PR TITLE
Airdrop - weighted allocation

### DIFF
--- a/src/app/holders/[type]/[id]/holders/route.ts
+++ b/src/app/holders/[type]/[id]/holders/route.ts
@@ -1,13 +1,7 @@
-import { Holder } from "@/components/pages/TokenMarket/list";
+import { Holder, TickHolder } from "@/components/pages/TokenMarket/list";
 import { API_HOST, AssetType } from "@/constants";
 import { BSV20 } from "@/types/bsv20";
 import { NextRequest, NextResponse } from "next/server";
-
-interface TickHolder {
-	address: string;
-	amt: number;
-	pct: number;
-}
 
 export const dynamic = "force-dynamic"; // defaults to auto
 

--- a/src/components/pages/TokenMarket/list.tsx
+++ b/src/components/pages/TokenMarket/list.tsx
@@ -11,6 +11,12 @@ export interface Holder {
 	amt: string;
 }
 
+export interface TickHolder {
+	address: string;
+	amt: number;
+	pct: number;
+}
+
 export type MarketData = {
 	accounts: number;
 	tick?: string;


### PR DESCRIPTION
- added new select field to Airdrop modal (choose equal or weighted allocation);
	- if Equal, everything remains the same - ticker holders and addresses can be combined;
	- if Weighted, addresses are not allowed since it can't be calculated;
- calculated weighted amounts using Math.floor() - this may result in some holders receiving 0;
- calculated remainder for Weighted allocation.